### PR TITLE
Feature/upgrade afnetworking

### DIFF
--- a/BDBOAuth1Manager.podspec
+++ b/BDBOAuth1Manager.podspec
@@ -9,11 +9,11 @@ Pod::Spec.new do |s|
   s.source    = { :git => 'https://github.com/bdbergeron/BDBOAuth1Manager.git', :tag => s.version.to_s }
   s.requires_arc = true
 
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
 
   s.source_files = 'BDBOAuth1Manager/**/*.{h,m}'
 
-  s.dependency 'AFNetworking/NSURLConnection', '~> 2.5.0'
-  s.dependency 'AFNetworking/NSURLSession', '~> 2.5.0'
+  s.dependency 'AFNetworking/NSURLConnection', '~> 2.6.0'
+  s.dependency 'AFNetworking/NSURLSession', '~> 2.6.0'
 end

--- a/BDBOAuth1Manager/BDBOAuth1RequestSerializer.m
+++ b/BDBOAuth1Manager/BDBOAuth1RequestSerializer.m
@@ -389,7 +389,7 @@ static NSDictionary *OAuthKeychainDictionaryForService(NSString *service) {
     NSString *requestURL    = [[[[request URL] absoluteString] componentsSeparatedByString:@"?"][0] bdb_URLEncode];
 
     NSArray *sortedQueryString = [[[[request URL] query] componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(compare:)];
-    NSString *queryString   = [[sortedQueryString componentsJoinedByString:@"&"] bdb_URLEncode];
+    NSString *queryString   = [[[sortedQueryString componentsJoinedByString:@"&"] bdb_URLEncodeSlashesAndQuestionMarks] bdb_URLEncode];
 
     NSString *requestString = [NSString stringWithFormat:@"%@&%@&%@", requestMethod, requestURL, queryString];
     NSData *requestData = [requestString dataUsingEncoding:NSUTF8StringEncoding];

--- a/BDBOAuth1Manager/Categories/NSString+BDBOAuth1Manager.h
+++ b/BDBOAuth1Manager/Categories/NSString+BDBOAuth1Manager.h
@@ -55,4 +55,14 @@
 
 - (NSString *)bdb_URLEncode;
 
+
+/**
+ *  Returns the given string with the '/' and '?' characters URL-encoded.
+ *
+ *  AFNetworking 2.6 no longer encodes '/' and '?' characters. See https://github.com/AFNetworking/AFNetworking/pull/2908
+ *
+ *  @return '?' and '/' URL-encoded string
+ */
+- (NSString *)bdb_URLEncodeSlashesAndQuestionMarks;
+
 @end

--- a/BDBOAuth1Manager/Categories/NSString+BDBOAuth1Manager.m
+++ b/BDBOAuth1Manager/Categories/NSString+BDBOAuth1Manager.m
@@ -46,4 +46,10 @@
                                                             kCFStringEncodingUTF8);
 }
 
+- (NSString *)bdb_URLEncodeSlashesAndQuestionMarks {
+    NSString *selfWithSlashesEscaped = [self stringByReplacingOccurrencesOfString:@"/" withString:@"%2F"];
+    NSString *selfWithQuestionMarksEscaped = [selfWithSlashesEscaped stringByReplacingOccurrencesOfString:@"?" withString:@"%3F"];
+    return selfWithQuestionMarksEscaped;
+}
+
 @end

--- a/BDBOAuth1ManagerDemo/BDBOAuth1ManagerDemo.xcodeproj/project.pbxproj
+++ b/BDBOAuth1ManagerDemo/BDBOAuth1ManagerDemo.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		05022751EC3D08B7DCB1D614 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8241A861A961B246A8EEBF16 /* libPods.a */; };
 		1F1F009767F0F6E090D7BECA /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8241A861A961B246A8EEBF16 /* libPods.a */; };
 		398963E796E95A7C01D298CB /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 577F1C9F5AB778827D69A425 /* libPods-osx.a */; };
-		666512CFA899B8288DA53355 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8241A861A961B246A8EEBF16 /* libPods.a */; };
 		96CDCC59BDDC25F2334E832A /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8241A861A961B246A8EEBF16 /* libPods.a */; };
 		D91E288F1B2648A7005F9455 /* BDBOAuth1ManagerTests_iOS.m in Sources */ = {isa = PBXBuildFile; fileRef = D91E288E1B2648A7005F9455 /* BDBOAuth1ManagerTests_iOS.m */; };
 		D91E28A91B278AE1005F9455 /* BDBOAuth1ManagerTests_OSX.m in Sources */ = {isa = PBXBuildFile; fileRef = D91E28A81B278AE1005F9455 /* BDBOAuth1ManagerTests_OSX.m */; };
@@ -38,16 +37,6 @@
 		E8F6169218496326008D9DC5 /* BDBFlickrPhotoset.m in Sources */ = {isa = PBXBuildFile; fileRef = E8F6169118496326008D9DC5 /* BDBFlickrPhotoset.m */; };
 		E8F6169518496578008D9DC5 /* BDBFlickrPhoto.m in Sources */ = {isa = PBXBuildFile; fileRef = E8F6169418496578008D9DC5 /* BDBFlickrPhoto.m */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		D91E28AA1B278AE1005F9455 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8F375BD1808743300C40148 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E8F375C41808743300C40148;
-			remoteInfo = "Twitter Demo";
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		33E03F5490FE80216781BCDE /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
@@ -389,7 +378,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				D91E28AB1B278AE1005F9455 /* PBXTargetDependency */,
 			);
 			name = "BDBOAuth1ManagerTests-OSX";
 			productName = "BDBOAuth1ManagerTests-OSX";
@@ -681,14 +669,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		D91E28AB1B278AE1005F9455 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E8F375C41808743300C40148 /* Twitter Demo */;
-			targetProxy = D91E28AA1B278AE1005F9455 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		E8284C6D18464ED900B3C6AA /* InfoPlist.strings */ = {

--- a/BDBOAuth1ManagerDemo/Podfile
+++ b/BDBOAuth1ManagerDemo/Podfile
@@ -4,12 +4,12 @@ platform :ios, '7.0'
 
 link_with 'Twitter Demo', 'Flickr Demo', 'BDBOAuth1ManagerTests-iOS'
 
-pod 'AFNetworking/UIKit', '~> 2.5.0'
+pod 'AFNetworking/UIKit', '~> 2.6.0'
 pod 'BBlock/UIKit', '~> 1.2.0'
 pod 'BDBOAuth1Manager', :path => '../'
 
 target :osx, :exclusive => true do
-platform :osx, '10.8'
+platform :osx, '10.9'
 link_with 'BDBOAuth1ManagerTests-OSX'
 
 pod 'BDBOAuth1Manager', :path => '../'

--- a/BDBOAuth1ManagerDemo/Podfile.lock
+++ b/BDBOAuth1ManagerDemo/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
-  - AFNetworking/NSURLConnection (2.5.0):
+  - AFNetworking/NSURLConnection (2.6.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.0):
+  - AFNetworking/NSURLSession (2.6.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.0)
-  - AFNetworking/Security (2.5.0)
-  - AFNetworking/Serialization (2.5.0)
-  - AFNetworking/UIKit (2.5.0):
+  - AFNetworking/Reachability (2.6.0)
+  - AFNetworking/Security (2.6.0)
+  - AFNetworking/Serialization (2.6.0)
+  - AFNetworking/UIKit (2.6.0):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - BBlock/UIKit (1.2.0)
   - BDBOAuth1Manager (1.5.0):
-    - AFNetworking/NSURLConnection (~> 2.5.0)
-    - AFNetworking/NSURLSession (~> 2.5.0)
+    - AFNetworking/NSURLConnection (~> 2.6.0)
+    - AFNetworking/NSURLSession (~> 2.6.0)
 
 DEPENDENCIES:
-  - AFNetworking/UIKit (~> 2.5.0)
+  - AFNetworking/UIKit (~> 2.6.0)
   - BBlock/UIKit (~> 1.2.0)
   - BDBOAuth1Manager (from `../`)
 
@@ -28,8 +28,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: 0f54cb5d16ce38c1b76948faffb8d5fb705021c7
-  BBlock: 90f0ae0e3ba94fc88be6b9a85b4adbb73b8a7c9a
-  BDBOAuth1Manager: 2e28773b58f880fb36b5cd3efcf0b1fefbc78a99
+  AFNetworking: 79f7eb1a0fcfa7beb409332b2ca49afe9ce53b05
+  BBlock: 11c666b6898c074eceb40fa56a901b96415ebf68
+  BDBOAuth1Manager: 0c2504af494803d48ae45b6622ddd448a740ff54
 
-COCOAPODS: 0.34.4
+COCOAPODS: 0.38.2


### PR DESCRIPTION
Upgrades AFNetworking to 2.6. Re-adds URL encoding of `?` and `/` characters, which were removed in AFNetworking 2.6. See https://github.com/AFNetworking/AFNetworking/pull/2908.
